### PR TITLE
Prevent multiple messages while waiting for bot response

### DIFF
--- a/code/src/app/chat/chat.tsx
+++ b/code/src/app/chat/chat.tsx
@@ -29,7 +29,7 @@ export default function Chat() {
         }}
 
       >
-       <Footer/>
+        <Footer />
         {messages.map((msg, i) => (
           <div
             key={i}
@@ -63,10 +63,12 @@ export default function Chat() {
               value={input}
               onChange={(e) => setInput(e.target.value)}
               required
+              disabled={isTyping}
             />
             <button
               type="submit"
               className="text-brown font-semibold ml-2 hover:text-cinereous transition"
+              disabled={isTyping}
             >
               Send
             </button>

--- a/code/src/app/hooks/useChat.ts
+++ b/code/src/app/hooks/useChat.ts
@@ -29,6 +29,10 @@ export function useChat() {
     // Function to handle sending a message to the backend server.
     const sendMessage = async (e: React.FormEvent) => {
         e.preventDefault();
+
+        // Prevent sending if already waiting for a response
+  if (isTyping) return;
+  
         const userMsg = input.trim();
         if (!userMsg) return;
 


### PR DESCRIPTION
This PR updates the chat flow to block user input and message sending until the backend responds.

Previously, users could continue typing or submit multiple messages while the bot was “typing,” which could cause overlapping requests and inconsistent conversation flow.