### PR TITLE
{WIP}Dashboard Accessibilty

### DIFF
--- a/code/src/app/dashboard/page.tsx
+++ b/code/src/app/dashboard/page.tsx
@@ -1,13 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import DashboardPage from "./dashboardPage";
 import { LeadRowData } from "./useLeads";
 
-export default async function Page() {
+export default function Page() {
+  const searchParams = useSearchParams();
+  const [authorized, setAuthorized] = useState(false);
+  const [rows, setRows] = useState<LeadRowData[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/leads`, { cache: "no-store" });
-  if (!res.ok) throw new Error("Failed to fetch leads");
+  useEffect(() => {
+    const provided = searchParams.get("p") || "";
+    const expected = process.env.NEXT_PUBLIC_DASHBOARD_KEY || "";
+    setAuthorized(Boolean(expected) && provided === expected);
+  }, [searchParams]);
 
-  const data = await res.json();
-  const rows = (data?.leads ?? []) as LeadRowData[];
+  useEffect(() => {
+    if (!authorized) return;
+    const api = process.env.NEXT_PUBLIC_API_URL;
+    if (!api) {
+      setError("Missing API URL");
+      return;
+    }
+    fetch(`${api}/leads`, { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch leads");
+        return res.json();
+      })
+      .then((data) => setRows((data?.leads ?? []) as LeadRowData[]))
+      .catch((e: any) => setError(String(e?.message || e)));
+  }, [authorized]);
+
+  if (!authorized) return null;
+  if (error) throw new Error(error);
+  if (!rows) return null;
 
   return <DashboardPage initialRows={rows} />;
 }


### PR DESCRIPTION
In this PR, implemented dashboard accessibility through a query parameter in the url

/dashboard now checks a query parameter p on the client. It compares p to NEXT_PUBLIC_DASHBOARD_KEY. If they match, it fetches leads and renders the dashboard; otherwise it renders nothing.

To render dashboard, enter url: http://localhost:3000/dashboard?p=NEXT_PUBLIC_DASHBOARD_KEY