### PR TITLE
Fixing Dashboard - Loading & Rendering Leads Data 

### DIFF
--- a/code/src/app/dashboard/dashboardPage.tsx
+++ b/code/src/app/dashboard/dashboardPage.tsx
@@ -11,7 +11,8 @@ import {
     useReactTable,
 } from '@tanstack/react-table';
 
-const PAGE_SIZE = 6;
+// Pagination 
+const PAGE_SIZE = 50;
 
 const statusColors: Record<LeadStatus, string> = {
     OPEN: "text-blue-700 font-semibold",

--- a/code/src/app/dashboard/page.tsx
+++ b/code/src/app/dashboard/page.tsx
@@ -14,7 +14,12 @@ export default function Page() {
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/leads`);
         if (!res.ok) return;
         const data = await res.json();
-        if (!cancelled) setRows((data?.leads ?? []) as LeadRowData[]);
+        if (!cancelled) {
+          const rowsData = Array.isArray(data)
+            ? (data as LeadRowData[])
+            : ((data?.leads ?? []) as LeadRowData[]);
+          setRows(rowsData);
+        }
       } catch {
         // ignore in static export; UI starts empty
       }

--- a/code/src/app/dashboard/page.tsx
+++ b/code/src/app/dashboard/page.tsx
@@ -1,35 +1,16 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import DashboardPage from "./dashboardPage";
-import { LeadRowData } from "./useLeads";
+
+import DashboardPage from './dashboardPage';
+import { useFetchLeads } from './useLeads';
 
 export default function Page() {
-  const [rows, setRows] = useState<LeadRowData[]>([]);
+  const { rows } = useFetchLeads();
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/leads`);
-        if (!res.ok) return;
-        const data = await res.json();
-        if (!cancelled) {
-          const rowsData = Array.isArray(data)
-            ? (data as LeadRowData[])
-            : ((data?.leads ?? []) as LeadRowData[]);
-          setRows(rowsData);
-        }
-      } catch {
-        // ignore in static export; UI starts empty
-      }
-    };
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  return rows.length === 0 ? (
+  <div className="text-white">Loading...</div>
+) : (
+  <DashboardPage initialRows={rows} />
+);
 
-  return <DashboardPage initialRows={rows} />;
 }
-

--- a/code/src/app/dashboard/page.tsx
+++ b/code/src/app/dashboard/page.tsx
@@ -1,13 +1,30 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import DashboardPage from "./dashboardPage";
 import { LeadRowData } from "./useLeads";
 
-export default async function Page() {
+export default function Page() {
+  const [rows, setRows] = useState<LeadRowData[]>([]);
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/leads`, { cache: "no-store" });
-  if (!res.ok) throw new Error("Failed to fetch leads");
-
-  const data = await res.json();
-  const rows = (data?.leads ?? []) as LeadRowData[];
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/leads`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setRows((data?.leads ?? []) as LeadRowData[]);
+      } catch {
+        // ignore in static export; UI starts empty
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return <DashboardPage initialRows={rows} />;
 }
+

--- a/code/src/app/dashboard/useLeads.ts
+++ b/code/src/app/dashboard/useLeads.ts
@@ -1,29 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { HistoryItem, LeadRowData, Message } from '../models/leads';
 
 export type LeadStatus = 'OPEN' | 'CLOSED' | 'QUALIFYING';
 
-export interface LeadRowData {
-  session_id: string;
-  name: string;
-  email: string;
-  mobile_number: string;
-  country: string;
-  status: LeadStatus;
-  remarks?: string;
-}
 
-export interface Message {
-  sender: string;
-  text: string;
-}
-
-interface HistoryItem {
-  type: 'human' | 'ai';
-  content: string;
-}
-
+// Makes a PATCH request to update lead status or remarks
 async function patchLeadAPI(
   update: Partial<Pick<LeadRowData, 'status' | 'remarks'>> & { session_id: string }
 ) {
@@ -38,6 +21,8 @@ async function patchLeadAPI(
   }
   return res.json();
 }
+
+// Hook to manage lead data, status updates, remarks, and chat history
 
 export function useLeads(initial: LeadRowData[] = []) {
   const [rows, setRows] = useState<LeadRowData[]>(initial);
@@ -58,6 +43,8 @@ export function useLeads(initial: LeadRowData[] = []) {
     return patchLeadAPI(update);
   };
 
+//  Updates the status of a lead row (OPEN / CLOSED / QUALIFYING)
+
   const onChangeStatus = useCallback(async (session_id: string, status: LeadStatus) => {
     setRows((prev) => prev.map((r) => (r.session_id === session_id ? { ...r, status } : r)));
     setSaving((s) => ({ ...s, [session_id]: true }));
@@ -69,6 +56,8 @@ export function useLeads(initial: LeadRowData[] = []) {
       setSaving((s) => ({ ...s, [session_id]: false }));
     }
   }, []);
+
+  // Saves updated remarks for a session
 
   const onSaveRemarks = useCallback(async (session_id: string, remarks: string) => {
     setSaving((s) => ({ ...s, [session_id]: true }));
@@ -83,6 +72,8 @@ export function useLeads(initial: LeadRowData[] = []) {
       setSaving((s) => ({ ...s, [session_id]: false }));
     }
   }, []);
+
+  // Loads chat history for a given session
 
   const loadHistory = useCallback(async (session_id: string) => {
     if (historyLoading[session_id]) return;
@@ -123,3 +114,45 @@ export function useLeads(initial: LeadRowData[] = []) {
     loadHistory,
   };
 }
+
+// Hook to fetch leads from API (used once during initialization)
+export function useFetchLeads() {
+  // State to store the fetched leads
+  const [rows, setRows] = useState<LeadRowData[]>([]);
+
+  useEffect(() => {
+    // Flag to prevent setting state after the component is unmounted
+    let isCancelled = false;
+
+    // Async function to fetch data
+    const fetchLeads = async () => {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/leads`);
+        if (!res.ok) return;
+        const data = await res.json();
+
+        // Only update state if component is still mounted
+        if (!isCancelled) {
+          const leads = Array.isArray(data) ? data : data?.leads ?? [];
+          setRows(leads as LeadRowData[]);
+        }
+      } catch {
+        console.log("error occurred");
+      }
+    };
+
+    // Call the fetch function on mount
+    fetchLeads();
+
+    // Cleanup: this flag prevents setting state on an unmounted component
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  // Return fetched leads
+  return { rows };
+}
+
+export type { LeadRowData };
+

--- a/code/src/app/dashboard/useLeads.ts
+++ b/code/src/app/dashboard/useLeads.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export type LeadStatus = 'OPEN' | 'CLOSED' | 'QUALIFYING';
 
@@ -41,6 +41,10 @@ async function patchLeadAPI(
 
 export function useLeads(initial: LeadRowData[] = []) {
   const [rows, setRows] = useState<LeadRowData[]>(initial);
+  // keep rows in sync when initial changes (e.g., after parent fetch completes)
+  useEffect(() => {
+    setRows(initial || []);
+  }, [initial]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState<Record<string, boolean>>({});
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});

--- a/code/src/app/landing/landing.tsx
+++ b/code/src/app/landing/landing.tsx
@@ -8,6 +8,7 @@ export default function Landing() {
 
       <h1 className="absolute top-[15%] left-[5%] ">
         AI-First Tech Services
+        
       </h1>
 
       {/* <div className="absolute top-[10%] right-0 translate-x-1/3 translate-y-1/5 "> */}

--- a/code/src/app/models/leads.ts
+++ b/code/src/app/models/leads.ts
@@ -1,0 +1,21 @@
+import { LeadStatus } from "../dashboard/useLeads";
+
+export interface LeadRowData {
+  session_id: string;
+  name: string;
+  email: string;
+  mobile_number: string;
+  country: string;
+  status: LeadStatus;
+  remarks?: string;
+}
+
+export interface Message {
+  sender: string;
+  text: string;
+}
+
+export interface HistoryItem {
+  type: 'human' | 'ai';
+  content: string;
+}


### PR DESCRIPTION
1. This PR updates dashboard/page.tsx to be a client component instead of a server component. The previous implementation attempted to fetch data on the server side, which led to issues during deployment,

2. GitHub Pages hosts static builds,therefore need to fetch leads dynamically on the client after the page loads. Thats why we require useEffect and useState.

3. Pagination increased to 50