### PR TITLE
Fix data fetching and sync leads state

### DIFF
--- a/code/src/app/dashboard/page.tsx
+++ b/code/src/app/dashboard/page.tsx
@@ -14,7 +14,12 @@ export default function Page() {
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/leads`);
         if (!res.ok) return;
         const data = await res.json();
-        if (!cancelled) setRows((data?.leads ?? []) as LeadRowData[]);
+        if (!cancelled) {
+          const rowsData = Array.isArray(data)
+            ? (data as LeadRowData[])
+            : ((data?.leads ?? []) as LeadRowData[]);
+          setRows(rowsData);
+        }
       } catch {
         // ignore in static export; UI starts empty
       }

--- a/code/src/app/dashboard/useLeads.ts
+++ b/code/src/app/dashboard/useLeads.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export type LeadStatus = 'OPEN' | 'CLOSED' | 'QUALIFYING';
 
@@ -41,6 +41,10 @@ async function patchLeadAPI(
 
 export function useLeads(initial: LeadRowData[] = []) {
   const [rows, setRows] = useState<LeadRowData[]>(initial);
+  // keep rows in sync when initial changes (e.g., after parent fetch completes)
+  useEffect(() => {
+    setRows(initial || []);
+  }, [initial]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState<Record<string, boolean>>({});
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});


### PR DESCRIPTION
This PR improves how the dashboard handles fetched lead data:
1. page.tsx
Added a safeguard for API responses that may return either a raw array or { leads: [...] }.
Normalized the data to always set rows as a LeadRowData[].

2.useLeads.tsx
Added a useEffect to keep rows in sync when the initial prop changes.
Prevents stale state in useLeads if parent (page.tsx) re-fetches or passes updated initialRows.