### PR TITLE
seo: update title to AI Solutions for Enterprises

### DIFF
--- a/code/src/app/landing/page.tsx
+++ b/code/src/app/landing/page.tsx
@@ -2,13 +2,13 @@ import type { Metadata } from "next";
 import LandingPro from "../components/landingPro";
 
 export const metadata: Metadata = {
-  title: "SmallTech | Custom Software & AI Solutions for Business",
+  title: "SmallTech | AI Solutions for Enterprises",
   description: "SmallTech builds tailored software solutions — AI integration, web & app development, cloud architecture, and continuous delivery for businesses of all sizes.",
   alternates: {
     canonical: "https://smalltech.in",
   },
   openGraph: {
-    title: "SmallTech | Custom Software & AI Solutions for Business",
+    title: "SmallTech | AI Solutions for Enterprises",
     description: "SmallTech builds tailored software solutions — AI integration, web & app development, cloud architecture, and continuous delivery for businesses of all sizes.",
     url: "https://smalltech.in",
     siteName: "SmallTech",

--- a/code/src/app/layout.tsx
+++ b/code/src/app/layout.tsx
@@ -10,9 +10,9 @@ const montserrat = Montserrat({
 });
 
 export const metadata: Metadata = {
-  title: "SmallTech | Custom Software & AI Solutions for Business",
+  title: "SmallTech | AI Solutions for Enterprises",
   description: "SmallTech builds tailored software solutions — AI integration, web & app development, cloud architecture, and continuous delivery for businesses of all sizes.",
-  keywords: ["software development", "AI integration", "web development", "app development", "cloud architecture", "tech solutions", "SmallTech", "custom software"],
+  keywords: ["AI solutions", "enterprise AI", "agentic AI", "AI integration", "web development", "app development", "cloud architecture", "tech solutions", "SmallTech"],
   robots: "index, follow",
   alternates: {
     canonical: "https://smalltech.in",
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
     shortcut: "/favicon.ico",
   },
   openGraph: {
-    title: "SmallTech | Custom Software & AI Solutions for Business",
+    title: "SmallTech | AI Solutions for Enterprises",
     description: "SmallTech builds tailored software solutions — AI integration, web & app development, cloud architecture, and continuous delivery for businesses of all sizes.",
     url: "https://smalltech.in",
     siteName: "SmallTech",
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "SmallTech | Custom Software & AI Solutions for Business",
+    title: "SmallTech | AI Solutions for Enterprises",
     description: "SmallTech builds tailored software solutions — AI integration, web & app development, cloud architecture, and continuous delivery for businesses of all sizes.",
     images: ["https://smalltech.in/logo.png"],
   },


### PR DESCRIPTION
## Change
Updates the page `<title>`, Open Graph title, and Twitter card title across `layout.tsx` and `landing/page.tsx`:

**Before:** `SmallTech | Custom Software & AI Solutions for Business`
**After:** `SmallTech | AI Solutions for Enterprises`

Also refreshes the `keywords` meta tag to drop `"software development"` / `"custom software"` and add `"AI solutions"`, `"enterprise AI"`, `"agentic AI"` to match the new positioning.

## Scope
- 2 files changed, no logic touched
- Cut from fresh `main` after PR #106 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)